### PR TITLE
Fixes to work correctly with Windows

### DIFF
--- a/keymaps/plantuml.cson
+++ b/keymaps/plantuml.cson
@@ -9,3 +9,6 @@
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-text-editor':
   'ctrl-cmd-p': 'plantuml:generate'
+
+'.platform-win32 atom-text-editor':
+  'ctrl-alt-p': 'plantuml:generate'

--- a/lib/file-utils.coffee
+++ b/lib/file-utils.coffee
@@ -13,9 +13,9 @@ class FileUtil
 
   @getPngFilePath:(file) ->
     pngFileName = FileUtil.getPngFilename(file)
-    filePath = file.path.split('/')
+    filePath = file.path.split(path.sep)
     filePath.pop()
-    filePath.join("/") + '/' + pngFileName
+    filePath.join(path.sep) + path.sep + pngFileName
 
 # private
   @saveIfModified:(buffer) ->


### PR DESCRIPTION
- In Windows the `CTRL-CMD-P` does not work: added Windows specific keymap `CTRL-ALT-P` 
- The path substitution for the PNG filename was Mac/Linux specific. Replaced hard coded path delimiter (`/`) with `path.sep`
