### PR TITLE
@startuml{path}

### DIFF
--- a/lib/file-utils.coffee
+++ b/lib/file-utils.coffee
@@ -47,7 +47,7 @@ class FileUtil
         dir = if isDir then expPath else path.dirname(expPath)
         # let the current path if absolute else takes buffer one
         unless path.isAbsolute(dir)
-          dir = [path.dirname(bufferFile.path), dir].join(path.sep)
+          dir = path.join(path.dirname(bufferFile.path), dir)
         # fetch filename, if none, gives editor's one
         if isDir
           # if it's a generated name aka no name
@@ -55,7 +55,7 @@ class FileUtil
           count++
         else
           fileName = path.basename(expPath)
-        pathes.push([dir, fileName].join(path.sep))
+        pathes.push(path.join(dir, fileName))
     return pathes
 
 # private

--- a/lib/file-utils.coffee
+++ b/lib/file-utils.coffee
@@ -16,8 +16,70 @@ class FileUtil
     filePath = file.path.split(path.sep)
     filePath.pop()
     filePath.join(path.sep) + path.sep + pngFileName
+  #
+  # function getPngPathesFromBuffer: looks in the buffer of a plantuml
+  # file if destinations are declared and output the in an array.
+  # @param {object} buffer - atom.buffer
+  # @return {array} pathes - each declaration path
+  #
+  @getPngPathesFromBuffer:(buffer) ->
+    keyword = '@startuml'
+    # FIXME: if you get better, then replace
+    content = buffer.cachedText
+    return if content.indexOf(keyword+'{') < 0
+    pathes = [] # to be returned
+    count = 0
+    bufferFile = buffer.file
+    for line in content.split("\n")
+      do (line) ->
+        # TODO: skip block comments /' ... '/
+        i = line.indexOf(keyword)
+        # if no a declaration or is a line comment.
+        return if i < 0 or line.substr(0, i).indexOf("'") > -1
+        # remove declaration
+        exp = line.substr(i + 9)
+        expPathIndex = exp.indexOf('{') + 1
+        expPathLen = exp.indexOf('}') - 1
+        # get the good
+        expPath = exp.substr(expPathIndex, expPathLen).trim()
+        isDir = FileUtil.pathIsDir(expPath)
+        # remove file if one
+        dir = if isDir then expPath else path.dirname(expPath)
+        # let the current path if absolute else takes buffer one
+        unless path.isAbsolute(dir)
+          dir = [path.dirname(bufferFile.path), dir].join(path.sep)
+        # fetch filename, if none, gives editor's one
+        if isDir
+          # if it's a generated name aka no name
+          fileName = FileUtil.getGenName(path.basename(bufferFile.path), count)
+          count++
+        else
+          fileName = path.basename(expPath)
+        pathes.push([dir, fileName].join(path.sep))
+    return pathes
 
 # private
+  #
+  # function getPngPathesFromBuffer: count >= 0, NAME.ext becomes NAME_001.png
+  # @param {string} name - name of a file
+  # @param {count} filename - position of filename in the plantuml source file
+  # @return {string} filename
+  #
+  @getGenName : (name, count) ->
+    c = ''
+    pad = (n, width) ->
+      n = String(n)
+      if n.length < width
+        new Array(width - n.length + 1).join(0) + n
+    if count > 0
+      c =  then "_" + pad(count, 3)
+    # same as getPngFilename but add _XXX if needed
+    fileName = path.basename(name, path.extname(name)) + c + '.png'
+
+  # for plantuml, trailing slash means a dir
+  @pathIsDir : (p) ->
+    p.trim().charAt(p.length - 1) == path.sep
+
   @saveIfModified:(buffer) ->
     if buffer.isModified()
       buffer.save()

--- a/lib/plantuml-utils.coffee
+++ b/lib/plantuml-utils.coffee
@@ -16,7 +16,7 @@ class PlantUml
       else
         atom.notifications.addWarning('PlantUml could not generate file.', {
           detail:'Please make sure PlantUml can write
-           to location of original file.'})
+           to location of target file ('+pngFilePath+').'})
 
     startTime = Date.now()
     new BufferedProcess({command, args, exit})

--- a/lib/plantuml.coffee
+++ b/lib/plantuml.coffee
@@ -23,11 +23,11 @@ module.exports = Plantuml =
       prepared = prepareFile(buffer)
       if prepared
         pngPathes = getPngPathesFromBuffer(buffer)
-        pngPathes = [ getPngFilePath(buffer.file) ] unless pngPathes # toString.call(pngPathes) != '[object Array]'
+        pngPathes = [ getPngFilePath(buffer.file) ] unless pngPathes
         umlFilePath = buffer.file.path
 
         for pngFilePath in pngPathes
-            writeAndOpenPng(umlFilePath, pngFilePath)
+          writeAndOpenPng(umlFilePath, pngFilePath)
       else
         atom.notifications.addWarning('Could not write file.', {
           detail:'Please make sure file can be written to disk.'})

--- a/lib/plantuml.coffee
+++ b/lib/plantuml.coffee
@@ -1,6 +1,6 @@
 {CompositeDisposable} = require 'atom'
 
-{prepareFile, getPngFilePath} = require './file-utils'
+{prepareFile, getPngFilePath, getPngPathesFromBuffer} = require './file-utils'
 {writeAndOpenPng} = require './plantuml-utils'
 
 module.exports = Plantuml =
@@ -22,9 +22,12 @@ module.exports = Plantuml =
       buffer = atom.workspace.getActivePaneItem().buffer
       prepared = prepareFile(buffer)
       if prepared
-        pngFilePath = getPngFilePath(buffer.file)
+        pngPathes = getPngPathesFromBuffer(buffer)
+        pngPathes = [ getPngFilePath(buffer.file) ] unless pngPathes # toString.call(pngPathes) != '[object Array]'
         umlFilePath = buffer.file.path
-        writeAndOpenPng(umlFilePath,pngFilePath)
+
+        for pngFilePath in pngPathes
+            writeAndOpenPng(umlFilePath, pngFilePath)
       else
         atom.notifications.addWarning('Could not write file.', {
           detail:'Please make sure file can be written to disk.'})

--- a/spec/in_file_declaration-spec.coffee
+++ b/spec/in_file_declaration-spec.coffee
@@ -29,12 +29,7 @@ describe "Plantuml", ->
     it "generates an in-file declared png", ->
       done = false
 
-      buffer.onDidSave((event)->
-        console.log(event)
-     )
-
       atom.workspace.onDidOpen((event)->
-        console.log(event)
         if event.uri.indexOf("generated.png") > -1
           done = true
       )

--- a/spec/in_file_declaration-spec.coffee
+++ b/spec/in_file_declaration-spec.coffee
@@ -1,0 +1,49 @@
+temp = require('temp').track()
+fs = require "fs"
+path = require "path"
+
+Plantuml = require '../lib/plantuml'
+
+describe "Plantuml", ->
+  [workspaceElement, activationPromise, directory, editor, buffer] = []
+
+  beforeEach ->
+    directory = temp.mkdirSync()
+
+    workspaceElement = atom.views.getView(atom.workspace)
+    activationPromise = atom.packages.activatePackage('plantuml')
+
+  describe "when editor is open and plantuml:generate event is triggered", ->
+    beforeEach ->
+      directory = temp.mkdirSync()
+      filePath = path.join(directory, 'tmpPlantuml.puml')
+      fs.writeFileSync(filePath, '')
+
+      waitsForPromise ->
+        atom.workspace.open(filePath).then((e) ->
+          editor = e
+          buffer = editor.getBuffer()
+          buffer.setText('@startuml{generated.png}\n(*) --> (*)\n@enduml')
+        )
+
+    it "generates an in-file declared png", ->
+      done = false
+
+      buffer.onDidSave((event)->
+        console.log(event)
+     )
+
+      atom.workspace.onDidOpen((event)->
+        console.log(event)
+        if event.uri.indexOf("generated.png") > -1
+          done = true
+      )
+
+      atom.commands.dispatch workspaceElement, 'plantuml:generate'
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        waitsFor ->
+          done is true


### PR DESCRIPTION
fixes mrohland/plantuml#10
The hook is, if we read "@startuml{" from the buffer, the process parses. As plantuml files are generally low in size, it's quick.
 `FileUtil.getPngPathesFromBuffer` returns array of pathes (or empty array)
if empty we fall to the legacy way `FileUtil.getPngFilePath(buffer.file)` (main usecase)
so we have minimum 1 path.
in any case we keep `writeAndOpenPng(umlFilePath, pngFilePath)`
