### PR TITLE
Changed remote.require "dialog" with remote.Dialog

### DIFF
--- a/lib/file-utils.coffee
+++ b/lib/file-utils.coffee
@@ -1,6 +1,6 @@
 remote = require "remote"
 path   = require "path"
-dialog = remote.require "dialog"
+dialog = remote.Dialog
 
 module.exports =
 class FileUtil


### PR DESCRIPTION
Changed `remote.require "dialog"` with `remote.Dialog` to avoid deprecation warnings. Fixes #19.